### PR TITLE
Rename documents

### DIFF
--- a/remarkapy/api.py
+++ b/remarkapy/api.py
@@ -68,6 +68,8 @@ class Client:
         self._config, self._config_filepath = get_config_or_raise(
             configfile, return_path=True
         )
+
+        # TODO We should store the token instead of refreshing at every init
         self._refresh_token()
 
     def _dump_config(self):
@@ -206,7 +208,6 @@ class Client:
 
         url = URLS.SYNC_FILE
 
-        print(data)
         return self._put(url, headers=headers, json=data)
 
     def _calculate_checksum(self, input_file: bytes):
@@ -242,7 +243,7 @@ class Client:
     "createdTime": "{metadata['createdTime']}",
     "lastModified": "{metadata['lastModified']}",
     "lastOpened": "{metadata['lastOpened']}",
-    "lastOpenedPage": "{metadata['lastOpenedPage']}",
+    "lastOpenedPage": {metadata['lastOpenedPage']},
     "parent": "{metadata['parent']}",
     "pinned": {str(metadata['pinned']).lower()},
     "type": "{metadata['Type']}",
@@ -271,8 +272,6 @@ class Client:
         url = URLS.GET_FILE + file_hash
 
         res = self._put(url, headers=headers, data=file_content)
-
-        print(file_content)
         return file_hash
 
     def _replace_hash(self, item_file_list: str, search_for: str, new_hash: str):
@@ -312,7 +311,7 @@ class Client:
 
         # Sync root
         res = self._get_root_folder_hash()
-        print(res)
+
         # Get item and extract current metadata
         item = self.get_item_by_id(_id, include_raw=True)
 
@@ -341,8 +340,6 @@ class Client:
 
         # Sync updated root
         root_hash = self._put_file(result)
-
-        print(root_hash)
 
         # Sync root
         print(self._sync_root(root_hash=root_hash))

--- a/remarkapy/api.py
+++ b/remarkapy/api.py
@@ -238,7 +238,7 @@ class Client:
     "lastOpened": "{metadata['lastOpened']}",
     "lastOpenedPage": "{metadata['lastOpenedPage']}",
     "parent": "{metadata['parent']}",
-    "pinned": {metadata['pinned']},
+    "pinned": {str(metadata['pinned']).lower()},
     "type": "{metadata['type']}",
     "visibleName": "{metadata['visibleName']}"
 }}
@@ -264,18 +264,20 @@ class Client:
 
         return self._put(url, headers=headers, data=metadata_raw)
 
-
     def rename_file(self, metadata_hash:str, new_name:str):
+
+        self._get_root_folder()
 
         # Should get file first and extract metadata
         response = self._get_file_by_hash(obj_hash=metadata_hash)
-
         metadata = response.json()
-        
+
         # Replace name without changing any other info
         metadata['visibleName'] = new_name
         
-        return self._put_file(metadata_hash, metadata)
+        self._put_file(metadata_hash, metadata)
+
+        # TODO re-attach metadata to content
 
     def _refresh_token(self):
         """
@@ -411,6 +413,8 @@ class Client:
         # List doc hashes on root folder
         response = self._get_file_by_hash(obj_hash=root_hash)
         obj_list = response.text.splitlines()
+
+        print(obj_list)
         root = {}
 
         # Add a file or a folder to a specific parent_hash or to root
@@ -491,6 +495,8 @@ class Client:
 
             response = self._get_file_by_hash(obj_hash=obj_hash)
             file_data = response.text.splitlines()
+
+            print(response.text)
 
             # Files
             files = []

--- a/remarkapy/api.py
+++ b/remarkapy/api.py
@@ -230,7 +230,7 @@ class Client:
 
         """
 
-        # trying this approach to maintain indentation. Otherwise CRC would mismatach
+        # trying this approach to maintain indentation. Otherwise CRC would mismatch
         # TODO find a better solution?
         metadata_raw = f'''{{
     "createdTime": "{metadata['createdTime']}",
@@ -245,6 +245,26 @@ class Client:
 '''
         return metadata_raw
 
+    def _put_file(self, hash, metadata):
+        
+        metadata_raw = self._preparare_metadata(metadata)
+
+        # Convert str to bytes
+        input_bytes = metadata_raw.encode('utf-8')
+
+        checksum = self._calculate_checksum(input_bytes)
+
+        headers = {
+            "Authorization": f"Bearer {self._config.usertoken}",
+            "user-agent": "remarkapy",
+            "x-goog-hash": f"crc32c={checksum}"
+        }
+    
+        url = URLS.GET_FILE + hash
+
+        return self._put(url, headers=headers, data=metadata_raw)
+
+
     def rename_file(self, metadata_hash:str, new_name:str):
 
         # Should get file first and extract metadata
@@ -254,15 +274,8 @@ class Client:
         
         # Replace name without changing any other info
         metadata['visibleName'] = new_name
-        metadata_raw = self._preparare_metadata(metadata)
-
-        # Convert str to bytes
-        input_bytes = metadata_raw.encode('utf-8')
-
-        checksum = self._calculate_checksum(input_bytes)
-
-        print(checksum)
-
+        
+        return self._put_file(metadata_hash, metadata)
 
     def _refresh_token(self):
         """

--- a/remarkapy/api.py
+++ b/remarkapy/api.py
@@ -433,9 +433,9 @@ class Client:
                 metadata = json_data
 
                 if folder_id:
-                    metadata['ID'] = folder_id
-                else:
-                    metadata['ID'] = _id
+                    metadata['folderID'] = folder_id
+
+                metadata['ID'] = _id
 
             else:
 

--- a/remarkapy/collections.py
+++ b/remarkapy/collections.py
@@ -1,0 +1,92 @@
+from .document import Document
+from .folder import Folder
+from typing import NoReturn, List, Union
+
+DocumentOrFolder = Union[Document, Folder]
+
+
+class Collection(object):
+    """A collection of meta items
+
+    This is basically the content of the Remarkable Cloud.
+
+    Attributes:
+        items: A list containing the items.
+    """
+
+    def __init__(self, *items: List[DocumentOrFolder]):
+        self.items: List[DocumentOrFolder] = []
+
+        for i in items:
+            self.items.append(i)
+
+    def add(self, doc_dict: dict) -> None:
+        """Add an item to the collection.
+        It wraps it in the correct class based on the Type parameter of the
+        dict.
+
+        Args:
+            doc_dict: A dict representing a document or folder.
+        """
+        if doc_dict.get("type", None) == "DocumentType":
+            self.add_document(doc_dict)
+        elif doc_dict.get("type", None) == "CollectionType":
+            self.add_folder(doc_dict)
+        else:
+            raise TypeError("Unsupported type: {_type}"
+                            .format(_type=doc_dict.get("type", None)))
+
+    def add_document(self, doc_dict: dict) -> None:
+        """Add a document to the collection
+
+        Args:
+            doc_dict: A dict representing a document.
+        """
+
+        self.items.append(Document(**doc_dict))
+
+    def add_folder(self, dir_dict: dict) -> None:
+        """Add a document to the collection
+
+        Args:
+            dir_dict: A dict representing a folder.
+        """
+
+        self.items.append(Folder(**dir_dict))
+
+    def parent(self, doc_or_folder: DocumentOrFolder) -> Folder:
+        """Returns the paren of a Document or Folder
+
+        Args:
+            doc_or_folder: A document or folder to get the parent from
+
+        Returns:
+            The parent folder.
+        """
+
+        results = [i for i in self.items if i.ID == doc_or_folder.ID]
+        if len(results) > 0 and isinstance(results[0], Folder):
+            return results[0]
+        else:
+            raise FolderNotFound("Could not found the parent of the document.")
+
+    def children(self, folder: Folder = None) -> List[DocumentOrFolder]:
+        """Get all the children from a folder
+
+        Args:
+            folder: A folder where to get the children from. If None, this will
+                get the children in the root.
+        Returns:
+            a list of documents an folders.
+        """
+
+        if folder:
+            return [i for i in self.items if i.Parent == folder.ID]
+        else:
+            return [i for i in self.items if i.Parent == ""]
+
+    def __len__(self) -> int:
+        return len(self.items)
+
+    def __getitem__(self, position: int) -> DocumentOrFolder:
+        return self.items[position]

--- a/remarkapy/document.py
+++ b/remarkapy/document.py
@@ -1,0 +1,18 @@
+from .meta import Meta
+
+class Document(Meta):
+    """ Document represents a real object expected in most
+    calls by the remarkable API
+    """
+
+    def __init__(self, **kwargs):
+        super(Document, self).__init__(**kwargs)
+        self.Type = "DocumentType"
+
+    def __str__(self):
+        """String representation of this object"""
+        return f"<rmapy.document.Document {self.ID}>"
+
+    def __repr__(self):
+        """String representation of this object"""
+        return self.__str__()

--- a/remarkapy/exceptions.py
+++ b/remarkapy/exceptions.py
@@ -1,0 +1,12 @@
+class RemarkableAPIError(Exception):
+    ...
+
+
+class ExpiredToken(RemarkableAPIError):
+    ...
+    
+class DocumentNotFound(Exception):
+    """Could not found a requested document"""
+    def __init__(self, msg):
+        super(DocumentNotFound, self).__init__(msg)
+

--- a/remarkapy/folder.py
+++ b/remarkapy/folder.py
@@ -1,0 +1,17 @@
+from .meta import Meta
+from typing import Optional
+
+
+class Folder(Meta):
+
+    def __init__(self, name: Optional[str] = None, **kwargs) -> None:
+        """Create a Folder instance
+
+        Args:
+            name: An optional name for this folder. It can be omitted
+        """
+        
+        super(Folder, self).__init__(**kwargs)
+        self.Type = "CollectionType"
+        if name:
+            self.visibleName = name

--- a/remarkapy/meta.py
+++ b/remarkapy/meta.py
@@ -20,6 +20,7 @@ class Meta(object):
 
     ID = ""
     Type = ""
+    folderID = ""
     visibleName = ""
     createdTime = None
     lastModified = None
@@ -47,6 +48,7 @@ class Meta(object):
         return {
             "ID": self.ID,
             "Type": self.Type,
+            "folderID": self.folderID,
             "visibleName": self.visibleName,
             "createdTime": self.createdTime,
             "lastModified": self.lastModified,

--- a/remarkapy/meta.py
+++ b/remarkapy/meta.py
@@ -1,0 +1,58 @@
+class Meta(object):
+    """ Meta represents a real object expected in most
+    calls by the remarkable API
+
+    Attributes:
+        ID: Id of the meta object.
+        Type: Currently there are only 2 known types: DocumentType &
+            CollectionType.
+        visibleName: The human name of the object.
+        createdTime: Time of creation of the object
+        lastModified: Time of last edit of the object
+        lastOpened: Last time the object was opened
+        lastOpenedPage: Last page that was read
+        currentPage: The current selected page of the object.
+        pinned: If the object is bookmarked.
+        parent: If empty, this object is in the root folder.
+        files: Contains a list of files that compose the item (usually .content , .epub, .pdf, .pagedata and .metadata)
+
+    """
+
+    ID = ""
+    Type = ""
+    visibleName = ""
+    createdTime = None
+    lastModified = None
+    lastOpened = None
+    lastOpenedPage = None
+    pinned = None
+    parent = ""
+    files = []
+
+    def __init__(self, **kwargs):
+        k_keys = self.to_dict().keys()
+
+        for k in k_keys:
+            setattr(self, k, kwargs.get(k, getattr(self, k)))
+
+    def to_dict(self) -> dict:
+        """Return a dict representation of this object.
+
+        Used for API Calls.
+
+        Returns
+            a dict of the current object.
+        """
+
+        return {
+            "ID": self.ID,
+            "Type": self.Type,
+            "visibleName": self.visibleName,
+            "createdTime": self.createdTime,
+            "lastModified": self.lastModified,
+            "lastOpened": self.lastOpened,
+            "lastOpenedPage": self.lastOpenedPage,
+            "pinned": self.pinned,
+            "parent": self.parent,
+            "files": self.files
+        }

--- a/remarkapy/meta.py
+++ b/remarkapy/meta.py
@@ -28,6 +28,7 @@ class Meta(object):
     lastOpenedPage = None
     pinned = None
     parent = ""
+    raw = ""
     files = []
 
     def __init__(self, **kwargs):
@@ -56,5 +57,6 @@ class Meta(object):
             "lastOpenedPage": self.lastOpenedPage,
             "pinned": self.pinned,
             "parent": self.parent,
-            "files": self.files
+            "files": self.files,
+            "raw": self.raw
         }

--- a/tests/test_ls.py
+++ b/tests/test_ls.py
@@ -1,0 +1,25 @@
+import sys
+sys.path.insert(0, '../')
+from remarkapy.api import Client
+import json
+
+api = Client()
+
+
+# Specify the file path
+file_path = 'output.json'
+
+# Fetch a collection of metadata items
+collection = api.get_items()
+
+# Convert the first document in the collection to a dictionary
+docs = []
+for doc in collection:
+    docs.append(doc.to_dict())
+
+# Dump the dictionary to a JSON file
+with open(file_path, 'w') as json_file:
+    json.dump(docs, json_file, indent=4)
+
+print(f"Data has been saved to {file_path}.")
+#

--- a/tests/test_rename.py
+++ b/tests/test_rename.py
@@ -1,0 +1,8 @@
+import sys
+sys.path.insert(0, '../')
+from remarkapy.api import Client
+import json
+
+api = Client()
+
+data = api.rename_item('ITEM_ID', new_name='coolname')


### PR DESCRIPTION
Another WIP...file renaming!

I'm trying to lay the foundations for all the basic file operations (doc upload, delete and rename).
It looks like Remarkable cloud expects a checksum (Since it's basically interacting with a Google Cloud instance) so we now have a new requirement: **crc32c**

There's also a new method that formats the metadata in the way the server expects it.

Note: This file rename implementation does work but breaks the link between .content and .metadata (it looks like it needs to be resynced even after a file rename -.-), so docs/book covers are broken until you manually click on them on a RM tablet. I’ll keep working on this over the next days

`api.rename_file(metadata_hash='47f5770qxda2cfcb8fa39f1c74yye61ffd46d5fd05cut102ffa14cc30e46ac34', new_name='Hello World')`

On a personal note I can say that Remarkable had the chance to make our job easier but nah...they want us to struggle! :D

